### PR TITLE
新增群組/解散群組功能，優化 TopToolbar 分區

### DIFF
--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -11,7 +11,7 @@ import "./Layout.css";
 const Layout = () => {
 	const [activeTool, setActiveTool] = useState("select");
 	const [isChatOpen, setIsChatOpen] = useState(false);
-	const [chatWidth, setChatWidth] = useState(300);
+	const [chatWidth, setChatWidth] = useState(400);
 	const [isResizing, setIsResizing] = useState(false);
 	const resizeTimeoutRef = useRef(null);
 	const [brushSettings, setBrushSettings] = useState({
@@ -112,7 +112,6 @@ const Layout = () => {
 			clearTimeout(resizeTimeoutRef.current);
 		}
 
-		// 使用 requestAnimationFrame 來平滑更新視覺效果
 		requestAnimationFrame(() => {
 			const chatContainer = document.querySelector(".chat-container");
 			if (chatContainer) {

--- a/src/components/toolbar/top-toolbar/ToolbarButtonGroup.jsx
+++ b/src/components/toolbar/top-toolbar/ToolbarButtonGroup.jsx
@@ -1,184 +1,162 @@
 import React, { useState, useRef, useEffect } from "react";
 import PropTypes from "prop-types";
-import {
-    Box,
-    IconButton,
-    Menu,
-    MenuItem,
-    useMediaQuery,
-    useTheme,
-    Tooltip,
-} from "@mui/material";
-import HistoryIcon from "@mui/icons-material/History"; // 編輯歷史
-import ContentCutIcon from "@mui/icons-material/ContentCut"; // 剪貼功能
-import FolderIcon from "@mui/icons-material/Folder"; // 檔案操作
-import ImageIcon from "@mui/icons-material/Image"; // 圖片操作
-import DeleteSweepIcon from "@mui/icons-material/DeleteSweep"; // 清除功能
+import { Box, IconButton, Menu, MenuItem, useMediaQuery, useTheme, Tooltip } from "@mui/material";
+import { History, CopyAll, Folder, Image, Group } from "@mui/icons-material";
 
 const getGroupIcon = (label) => {
-    switch (label) {
-        case "編輯操作":
-            return <HistoryIcon />;
-        case "剪貼功能":
-            return <ContentCutIcon />;
-        case "檔案操作":
-            return <FolderIcon />;
-        case "圖片操作":
-            return <ImageIcon />;
-        case "其他功能":
-            return <DeleteSweepIcon />;
-        default:
-            return null;
-    }
+	switch (label) {
+		case "復原與重做":
+			return <History />;
+		case "剪貼簿":
+			return <CopyAll />;
+		case "群組功能":
+			return <Group />;
+		case "檔案操作":
+			return <Folder />;
+		case "圖片操作":
+			return <Image />;
+		// case "其他功能":
+		// 	return <DeleteSweep />;
+		default:
+			return null;
+	}
 };
 
-// 新增 Tooltip title 產生函式
-const getTooltipTitle = (label) => {
-    switch (label) {
-        case "編輯操作":
-            return "編輯操作";
-        case "剪貼功能":
-            return "剪貼功能";
-        case "檔案操作":
-            return "檔案操作";
-        case "圖片操作":
-            return "圖片操作";
-        case "其他功能":
-            return "其他功能";
-        default:
-            return label;
-    }
-};
+const ToolbarButtonGroup = ({ children, label, index = 0, totalGroups = 1, availableWidth = Infinity }) => {
+	const [anchorEl, setAnchorEl] = useState(null);
+	const theme = useTheme();
+	const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+	const buttonGroupRef = useRef(null);
 
-const ToolbarButtonGroup = ({
-    children,
-    label,
-    index = 0,
-    totalGroups = 1,
-    availableWidth = Infinity,
-}) => {
-    const [anchorEl, setAnchorEl] = useState(null);
-    const theme = useTheme();
-    const isMobile = useMediaQuery(theme.breakpoints.down("md"));
-    const buttonGroupRef = useRef(null);
+	const shouldCollapse = React.useMemo(() => {
+		// 如果是移動端，直接折疊
+		if (isMobile) return true;
 
-    const shouldCollapse = React.useMemo(() => {
-        // 如果是移動端，直接折疊
-        if (isMobile) return true;
+		// 計算當前按鈕組需要的空間
+		const minWidthPerGroup = 120; // 完整按鈕組的最小寬度
+		const collapsedWidth = 48; // 濃縮後的寬度
+		const spacing = 8; // 按鈕組之間的間距
 
-        // 計算當前按鈕組需要的空間
-        const minWidthPerGroup = 120; // 完整按鈕組的最小寬度
-        const collapsedWidth = 48; // 濃縮後的寬度
-        const spacing = 8; // 按鈕組之間的間距
+		// 計算從右到左到目前按鈕組需要的總空間
+		const currentGroupPosition = (totalGroups - index) * (minWidthPerGroup + spacing);
 
-        // 計算從右到左到目前按鈕組需要的總空間
-        const currentGroupPosition = (totalGroups - index) * (minWidthPerGroup + spacing);
+		// 如果目前位置的空間不足，則需要折疊
+		const collapsedButtonsSpace = index * (collapsedWidth + spacing);
+		const availableSpaceForCurrentGroup = availableWidth - collapsedButtonsSpace;
 
-        // 如果目前位置的空間不足，則需要折疊
-        const collapsedButtonsSpace = index * (collapsedWidth + spacing);
-        const availableSpaceForCurrentGroup = availableWidth - collapsedButtonsSpace;
+		return availableSpaceForCurrentGroup < currentGroupPosition;
+	}, [isMobile, index, totalGroups, availableWidth]);
 
-        return availableSpaceForCurrentGroup < currentGroupPosition;
-    }, [isMobile, index, totalGroups, availableWidth]);
+	// 當按鈕組展開/折疊狀態改變時，強制重新計算佈局
+	useEffect(() => {
+		if (buttonGroupRef.current) {
+			buttonGroupRef.current.style.display = "none";
+			buttonGroupRef.current.style.display = "";
+		}
+	}, [shouldCollapse]);
 
-    // 當按鈕組展開/折疊狀態改變時，強制重新計算佈局
-    useEffect(() => {
-        if (buttonGroupRef.current) {
-            buttonGroupRef.current.style.display = 'none';
-            buttonGroupRef.current.style.display = '';
-        }
-    }, [shouldCollapse]);
+	const handleClick = (event) => {
+		setAnchorEl(event.currentTarget);
+	};
 
-    const handleClick = (event) => {
-        setAnchorEl(event.currentTarget);
-    };
-
-    const handleClose = () => {
-        setAnchorEl(null);
-    };
-    return (
-        <Box ref={buttonGroupRef}>
-            {!shouldCollapse ? (
-                <Box sx={{ 
-                    display: "flex", 
-                    alignItems: "center",
-                    transition: "all 0.3s ease"
-                }}>
-                    {children}
-                </Box>
-            ) : (
-                <>
-                    <Tooltip title={getTooltipTitle(label)} placement="bottom">
-                        <IconButton
-                            aria-label={label}
-                            onClick={handleClick}
-                            size="small"
-                            sx={{
-                                bgcolor: anchorEl ? "action.selected" : "transparent",
-                                "&:hover": {
-                                    bgcolor: "action.hover",
-                                },
-                                transition: "all 0.3s ease"
-                            }}
-                        >
-                            {getGroupIcon(label)}
-                        </IconButton>
-                    </Tooltip>
-                    <Menu
-                        anchorEl={anchorEl}
-                        open={Boolean(anchorEl)}
-                        onClose={handleClose}
-                        onClick={handleClose}
-                        anchorOrigin={{
-                            vertical: "bottom",
-                            horizontal: "center",
-                        }}
-                        transformOrigin={{
-                            vertical: "top",
-                            horizontal: "center",
-                        }}
-                        PaperProps={{
-                            sx: {
-                                bgcolor: "background.paper",
-                                "& .MuiMenuItem-root": {
-                                    px: 1,
-                                    py: 0.5,
-                                    minHeight: "auto",
-                                    justifyContent: "center",
-                                },
-                                minWidth: "auto",
-                            },
-                        }}
-                        TransitionProps={{
-                            mountOnEnter: true,
-                            unmountOnExit: true,
-                            timeout: 300
-                        }}
-                    >
-                        {React.Children.map(children, (child) => {
-                            if (!child || child.type.name === "Divider") return null;
-                            return (
-                                <MenuItem>
-                                    {React.cloneElement(child, {
-                                        size: "small",
-                                        sx: { p: 0.5 },
-                                })}
-                                </MenuItem>
-                            );
-                        })}
-                    </Menu>
-                </>
-            )}
-        </Box>
-    );
+	const handleClose = () => {
+		setAnchorEl(null);
+	};
+	return (
+		<Box ref={buttonGroupRef}>
+			{!shouldCollapse ? (
+				<Box
+					sx={{
+						display: "flex",
+						alignItems: "center",
+						transition: "all 0.3s ease",
+					}}
+				>
+					{children}
+				</Box>
+			) : (
+				<>
+					<Tooltip title={label} placement="bottom">
+						<IconButton
+							aria-label={label}
+							onClick={handleClick}
+							size="small"
+							sx={{
+								bgcolor: anchorEl ? "action.selected" : "transparent",
+								"&:hover": {
+									bgcolor: "action.hover",
+								},
+								transition: "all 0.3s ease",
+							}}
+						>
+							{getGroupIcon(label)}
+						</IconButton>
+					</Tooltip>
+					<Menu
+						anchorEl={anchorEl}
+						open={Boolean(anchorEl)}
+						onClose={handleClose}
+						onClick={handleClose}
+						anchorOrigin={{
+							vertical: "bottom",
+							horizontal: "center",
+						}}
+						transformOrigin={{
+							vertical: "top",
+							horizontal: "center",
+						}}
+						PaperProps={{
+							sx: {
+								bgcolor: "background.paper",
+								"& .MuiMenuItem-root": {
+									px: 1,
+									py: 0.5,
+									minHeight: "auto",
+									justifyContent: "center",
+								},
+								minWidth: "auto",
+							},
+						}}
+						TransitionProps={{
+							mountOnEnter: true,
+							unmountOnExit: true,
+							timeout: 300,
+						}}
+					>
+						{React.Children.map(children, (child) => {
+							if (!child || child.type.name === "Divider") return null;
+							const tooltipTitle = child.props && child.props.title ? child.props.title : "";
+							const noAutoClose = ["復原與重做", "剪貼簿", "群組功能"].includes(label);
+							const menuItemProps = noAutoClose
+								? { onClick: (e) => e.stopPropagation() }
+								: { onClick: handleClose };
+							return (
+								<MenuItem {...menuItemProps}>
+									<Tooltip title={tooltipTitle} placement="right" disableInteractive>
+										<span>
+											{React.cloneElement(child, {
+												size: "small",
+												sx: { p: 0.5 },
+												title: undefined, // 避免原本 title 造成下方顯示
+											})}
+										</span>
+									</Tooltip>
+								</MenuItem>
+							);
+						})}
+					</Menu>
+				</>
+			)}
+		</Box>
+	);
 };
 
 ToolbarButtonGroup.propTypes = {
-    children: PropTypes.node.isRequired,
-    label: PropTypes.string.isRequired,
-    index: PropTypes.number,
-    totalGroups: PropTypes.number,
-    availableWidth: PropTypes.number,
+	children: PropTypes.node.isRequired,
+	label: PropTypes.string.isRequired,
+	index: PropTypes.number,
+	totalGroups: PropTypes.number,
+	availableWidth: PropTypes.number,
 };
 
 export default ToolbarButtonGroup;

--- a/src/components/toolbar/top-toolbar/TopToolbar.jsx
+++ b/src/components/toolbar/top-toolbar/TopToolbar.jsx
@@ -7,6 +7,8 @@ import { handleSaveFile, handleLoadFile, handleFileInputChange } from "../../../
 import { importImage } from "../../../helpers/image/ImageImport";
 import ImageExportDialog from "../../image/ImageExportDialog";
 import { cut, copy, paste, hasClipboardContent } from "../../../helpers/clipboard/ClipboardOperations";
+import * as fabric from "fabric";
+import { groupSelectedObjects, ungroupSelectedGroup } from "../../../helpers/group/GroupUtils";
 
 const TopToolbar = ({ onClearClick, canvas, canvasReady, chatWidth = 0 }) => {
 	const fileInputRef = useRef(null);
@@ -16,6 +18,8 @@ const TopToolbar = ({ onClearClick, canvas, canvasReady, chatWidth = 0 }) => {
 	const [hasSelectedObject, setHasSelectedObject] = useState(false);
 	const [canPaste, setCanPaste] = useState(false);
 	const [availableWidth, setAvailableWidth] = useState(0);
+	const [canGroup, setCanGroup] = useState(false);
+	const [canUngroup, setCanUngroup] = useState(false);
 	const RESERVED_LAST_BUTTON_WIDTH = 72; // 與 TopToolbarButtons 保持一致
 
 	// 監聽工具欄容器寬度變化
@@ -47,7 +51,16 @@ const TopToolbar = ({ onClearClick, canvas, canvasReady, chatWidth = 0 }) => {
 
 		// 監聽選取狀態變化
 		const handleSelection = () => {
-			setHasSelectedObject(!!canvas?.getActiveObject());
+			const activeObject = canvas?.getActiveObject();
+			setHasSelectedObject(!!activeObject);
+			setCanGroup(
+				activeObject &&
+					(activeObject instanceof fabric.ActiveSelection ||
+						(activeObject.forEachObject && typeof activeObject.forEachObject === "function")) &&
+					activeObject.size &&
+					activeObject.size() > 1
+			);
+			setCanUngroup(activeObject && activeObject.type === "group");
 		};
 
 		if (canvas) {
@@ -119,6 +132,13 @@ const TopToolbar = ({ onClearClick, canvas, canvasReady, chatWidth = 0 }) => {
 	const handleImportClick = () => {
 		imageInputRef.current?.click();
 	};
+
+	const handleGroup = () => {
+		groupSelectedObjects(canvas);
+	};
+	const handleUngroup = () => {
+		ungroupSelectedGroup(canvas);
+	};
 	return (
 		<Box
 			ref={containerRef}
@@ -152,11 +172,15 @@ const TopToolbar = ({ onClearClick, canvas, canvasReady, chatWidth = 0 }) => {
 					onRedoClick={handleRedo}
 					onExportClick={handleExportClick}
 					onImportClick={handleImportClick}
+					onGroupClick={handleGroup}
+					onUngroupClick={handleUngroup}
 					canvas={canvas}
 					hasSelectedObject={hasSelectedObject}
 					canPaste={canPaste}
 					chatWidth={chatWidth}
 					availableWidth={availableWidth}
+					canGroup={canGroup}
+					canUngroup={canUngroup}
 				/>
 			</Paper>
 

--- a/src/components/toolbar/top-toolbar/TopToolbarButtons.jsx
+++ b/src/components/toolbar/top-toolbar/TopToolbarButtons.jsx
@@ -8,11 +8,13 @@ import {
 	ContentCut,
 	ContentCopy,
 	ContentPaste,
-	Image,
-	FileUpload,
+	Download,
+	AddPhotoAlternate,
+	GroupAdd,
+	GroupRemove,
+	Undo,
+	Redo,
 } from "@mui/icons-material";
-import UndoIcon from "@mui/icons-material/Undo";
-import RedoIcon from "@mui/icons-material/Redo";
 import ToolbarButtonGroup from "./ToolbarButtonGroup";
 
 const TopToolbarButtons = ({
@@ -29,51 +31,43 @@ const TopToolbarButtons = ({
 	canvas,
 	hasSelectedObject,
 	canPaste,
-	chatWidth = 0,
 	availableWidth = Infinity,
+	onGroupClick,
+	onUngroupClick,
+	canGroup,
+	canUngroup,
 }) => {
-	// 移除本地 availableWidth 狀態與 useEffect
-
 	return (
-		<Box 
+		<Box
 			className="top-toolbar-tools"
 			sx={{
-				display: 'flex',
+				display: "flex",
 				gap: 1,
-				alignItems: 'center',
-				position: 'relative',
-				'&::-webkit-scrollbar': { display: 'none' },
-				msOverflowStyle: 'none',
-				scrollbarWidth: 'none',
-				width: '100%',
+				alignItems: "center",
+				position: "relative",
+				"&::-webkit-scrollbar": { display: "none" },
+				msOverflowStyle: "none",
+				scrollbarWidth: "none",
+				width: "100%",
 				height: 48,
-				justifyContent: 'flex-start',
+				justifyContent: "flex-start",
 			}}
-		><ToolbarButtonGroup 
-				label="編輯操作" 
-				index={0} 
-				totalGroups={5} 
-				availableWidth={availableWidth}
-			>
+		>
+			<ToolbarButtonGroup label="復原與重做" index={0} totalGroups={6} availableWidth={availableWidth}>
 				<Tooltip title="復原" placement="bottom">
 					<IconButton onClick={onUndoClick}>
-						<UndoIcon />
+						<Undo />
 					</IconButton>
 				</Tooltip>
 
 				<Tooltip title="重做" placement="bottom">
 					<IconButton onClick={onRedoClick}>
-						<RedoIcon />
+						<Redo />
 					</IconButton>
 				</Tooltip>
 			</ToolbarButtonGroup>
-
-			<Divider orientation="vertical" flexItem />			<ToolbarButtonGroup 
-				label="剪貼功能" 
-				index={1} 
-				totalGroups={5} 
-				availableWidth={availableWidth}
-			>
+			<Divider orientation="vertical" sx={{ height: "auto", minHeight: 30 }} />
+			<ToolbarButtonGroup label="剪貼簿" index={1} totalGroups={6} availableWidth={availableWidth}>
 				<Tooltip title="剪下" placement="bottom">
 					<IconButton onClick={onCutClick} disabled={!hasSelectedObject}>
 						<ContentCut />
@@ -92,61 +86,53 @@ const TopToolbarButtons = ({
 					</IconButton>
 				</Tooltip>
 			</ToolbarButtonGroup>
-
-			<Divider orientation="vertical" flexItem />			<ToolbarButtonGroup 
-				label="檔案操作"
-				index={2}
-				totalGroups={5}
-				availableWidth={availableWidth}
-			>
-				<Tooltip title="保存" placement="bottom">
+			<Divider orientation="vertical" sx={{ height: "auto", minHeight: 30 }} />
+			<ToolbarButtonGroup label="群組功能" index={2} totalGroups={6} availableWidth={availableWidth}>
+				<Tooltip title="成為群組" placement="bottom">
+					<IconButton onClick={onGroupClick} disabled={!canGroup}>
+						<GroupAdd />
+					</IconButton>
+				</Tooltip>
+				<Tooltip title="解散群組" placement="bottom">
+					<IconButton onClick={onUngroupClick} disabled={!canUngroup}>
+						<GroupRemove />
+					</IconButton>
+				</Tooltip>
+			</ToolbarButtonGroup>
+			<Divider orientation="vertical" sx={{ height: "auto", minHeight: 30 }} />
+			<ToolbarButtonGroup label="檔案操作" index={3} totalGroups={6} availableWidth={availableWidth}>
+				<Tooltip title="保存檔案" placement="bottom">
 					<IconButton onClick={onSaveClick}>
 						<Save />
 					</IconButton>
 				</Tooltip>
 
-				<Tooltip title="開啟" placement="bottom">
+				<Tooltip title="開啟檔案" placement="bottom">
 					<IconButton onClick={onLoadClick}>
 						<FileOpen />
 					</IconButton>
 				</Tooltip>
 			</ToolbarButtonGroup>
-
-			<Divider orientation="vertical" flexItem />
-
-			<ToolbarButtonGroup 
-				label="圖片操作"
-				index={3}
-				totalGroups={5}
-				availableWidth={availableWidth}
-			>
+			<Divider orientation="vertical" sx={{ height: "auto", minHeight: 30 }} />
+			<ToolbarButtonGroup label="圖片操作" index={4} totalGroups={6} availableWidth={availableWidth}>
 				<Tooltip title="匯入圖片" placement="bottom">
 					<IconButton onClick={onImportClick}>
-						<FileUpload />
+						<AddPhotoAlternate />
 					</IconButton>
 				</Tooltip>
 
 				<Tooltip title="匯出圖片" placement="bottom">
 					<IconButton onClick={onExportClick}>
-						<Image />
+						<Download />
 					</IconButton>
 				</Tooltip>
 			</ToolbarButtonGroup>
-
-			<Divider orientation="vertical" flexItem />
-
-			<ToolbarButtonGroup 
-				label="其他功能"
-				index={4}
-				totalGroups={5}
-				availableWidth={availableWidth}
-			>
-				<Tooltip title="清除畫布" placement="bottom">
-					<IconButton onClick={onClearClick}>
-						<Delete />
-					</IconButton>
-				</Tooltip>
-			</ToolbarButtonGroup>
+			<Divider orientation="vertical" sx={{ height: "auto", minHeight: 30 }} />
+			<Tooltip title="清除畫布" placement="bottom">
+				<IconButton onClick={onClearClick}>
+					<Delete />
+				</IconButton>
+			</Tooltip>
 		</Box>
 	);
 };
@@ -167,6 +153,10 @@ TopToolbarButtons.propTypes = {
 	canPaste: PropTypes.bool,
 	chatWidth: PropTypes.number,
 	availableWidth: PropTypes.number,
+	onGroupClick: PropTypes.func.isRequired,
+	onUngroupClick: PropTypes.func.isRequired,
+	canGroup: PropTypes.bool,
+	canUngroup: PropTypes.bool,
 };
 
 export default TopToolbarButtons;

--- a/src/helpers/canvas/CanvasOperations.js
+++ b/src/helpers/canvas/CanvasOperations.js
@@ -31,7 +31,7 @@ export const clearCanvas = (canvas) => {
 	canvas.isClearingAll = true;
 
 	canvas.clear();
-	canvas.backgroundColor = "#ffffff"; 
+	canvas.backgroundColor = "#ffffff";
 	canvas.isClearingAll = false;
 
 	canvas.renderAll();
@@ -59,7 +59,7 @@ export const setDrawingMode = (canvas, isDrawingMode) => {
 
 export const addImageToCanvas = (canvas, imageData) => {
 	if (!canvas || !imageData) return;
-	
+
 	const imgObj = new Image();
 	imgObj.src = imageData;
 	imgObj.onload = () => {
@@ -70,10 +70,7 @@ export const addImageToCanvas = (canvas, imageData) => {
 		const windowHeight = window.innerHeight;
 
 		// 計算縮放比例，讓圖片填滿視窗
-		const scale = Math.max(
-			windowWidth / fabricImage.width,
-			windowHeight / fabricImage.height
-		);
+		const scale = Math.max(windowWidth / fabricImage.width, windowHeight / fabricImage.height);
 
 		// 設定圖片屬性
 		fabricImage.set({

--- a/src/helpers/group/GroupUtils.js
+++ b/src/helpers/group/GroupUtils.js
@@ -1,0 +1,36 @@
+import * as fabric from "fabric";
+
+/**
+ * 將多個選取物件群組化
+ * @param {fabric.Canvas} canvas - 畫布實例
+ */
+export function groupSelectedObjects(canvas) {
+	if (!canvas.getActiveObject()) {
+		return;
+	}
+
+	if (canvas.getActiveObject().type !== "activeSelection" && canvas.getActiveObject().type !== "activeselection") {
+		return;
+	}
+	const group = new fabric.Group(canvas.getActiveObject().removeAll());
+	canvas.add(group);
+	canvas.setActiveObject(group);
+	canvas.requestRenderAll();
+}
+
+/**
+ * 解散目前選取的群組
+ * @param {fabric.Canvas} canvas - 畫布實例
+ */
+export function ungroupSelectedGroup(canvas) {
+	const group = canvas.getActiveObject();
+	if (!group || group.type !== "group") {
+		return;
+	}
+	canvas.remove(group);
+	const sel = new fabric.ActiveSelection(group.removeAll(), {
+		canvas: canvas,
+	});
+	canvas.setActiveObject(sel);
+	canvas.requestRenderAll();
+}


### PR DESCRIPTION
1. 新增群組與解散群組功能
   - 實作「群組」與「解散群組」功能，支援多物件選取後群組化，以及群組物件的解散。

2. TopToolbar 分區與 RWD 優化
   - 將「復原與重做」、「剪貼簿」、「群組功能」、「檔案操作」、「圖片操作」等功能分為獨立 ToolbarButtonGroup，並以 Divider 分隔。
   - RWD 下各群組自動收合為主按鈕，展開時子按鈕以 Tooltip（右側）顯示說明。

3. 群組/剪貼簿/復原群組 UX 強化
   - 「復原與重做」、「剪貼簿」、「群組功能」三個群組的子按鈕，點擊後不會自動收合選單，方便連續操作。
   - 其他群組（如檔案操作、圖片操作）維持點擊後自動收合。